### PR TITLE
fix runtime exception caused by illegal reflective-access operations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,8 @@ compileJava {
 task execute(type: JavaExec) {
     main = findProperty("mainClass") ?: ""
     classpath = sourceSets.main.runtimeClasspath
+    jvmArgs += '--add-opens=java.base/java.lang=ALL-UNNAMED' // Upgrade to Java 21
+    jvmArgs += '--add-opens=java.base/java.time=ALL-UNNAMED' // Upgrade to Java 21
 }
 
 license {


### PR DESCRIPTION
Some samples are failing due to illegal reflective access after upgrading to java21. 

https://github.com/cadence-workflow/cadence-java-samples/issues/278

More details 
https://docs.oracle.com/en/java/javase/17/migrate/migrating-jdk-8-later-jdk-releases.html#GUID-C2BE0C3C-1EE4-4411-B112-9A360427D638